### PR TITLE
Update mod for 1.21.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,14 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.20.5
-	yarn_mappings=1.20.5+build.1
-	loader_version=0.15.10
+        minecraft_version=1.21.7
+        yarn_mappings=1.21.7+build.8
+        loader_version=0.16.14
 
 # Mod Properties
-	mod_version = 1.5.2+1.20.5
+        mod_version = 1.5.2+1.21.7
 	maven_group = com.minenash
 	archives_base_name = rebind-all-the-keys
 
 # Dependencies
-	fabric_version=0.97.5+1.20.5
+        fabric_version=0.129.0+1.21.7

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,6 +28,6 @@
   "depends": {
     "fabricloader": ">=0.11.3",
     "fabric": "*",
-    "minecraft": ">=1.20.5"
+    "minecraft": ">=1.21.0"
   }
 }


### PR DESCRIPTION
## Summary
- update Gradle properties to Minecraft 1.21.7 toolchain and dependencies
- bump minimum Minecraft version in fabric.mod.json

## Testing
- `./gradlew build --no-daemon` *(fails: waiting for fabric-loom cache lock)*

------
https://chatgpt.com/codex/tasks/task_e_6883e2eda724832a981a62774d099e9b